### PR TITLE
fix: make sure withMdx theme options can be false

### DIFF
--- a/@rocketseat/gatsby-theme-docs-core/util/with-default.js
+++ b/@rocketseat/gatsby-theme-docs-core/util/with-default.js
@@ -5,7 +5,6 @@ module.exports = (themeOptions) => {
   const branch = themeOptions.branch || `main`;
   const baseDir = themeOptions.baseDir || ``;
   const { withMdx = true } = themeOptions;
-
   const { githubUrl, repositoryUrl = '' } = themeOptions;
 
   return {

--- a/@rocketseat/gatsby-theme-docs-core/util/with-default.js
+++ b/@rocketseat/gatsby-theme-docs-core/util/with-default.js
@@ -4,7 +4,8 @@ module.exports = (themeOptions) => {
   const docsPath = themeOptions.docsPath || `docs`;
   const branch = themeOptions.branch || `main`;
   const baseDir = themeOptions.baseDir || ``;
-  const withMdx = themeOptions.withMdx || true;
+  const { withMdx = true } = themeOptions;
+
   const { githubUrl, repositoryUrl = '' } = themeOptions;
 
   return {


### PR DESCRIPTION
Hi!

Here's a little patch I had to do to be able to disable MDX from `gatsby-theme-docs-core`.

**Changes proposed**

The previous `||` operator will always end up with a `true` value when `withMdx: false` is provided as a theme option.

